### PR TITLE
Add China (MeshCN) to communities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Note: Meshtastic® is a registered trademark of [Meshtastic LLC](https://meshtas
     - [Prince Edward Island](#prince-edward-island)
     - [Quebec](#quebec)
     - [Saskatchewan](#saskatchewan)
+  - [China](#china)
   - [Finland](#finland)
   - [Germany](#germany)
   - [India](#india)
@@ -231,6 +232,10 @@ For online communities, forums and gathering places, that are not nessisarily ge
 
 #### Saskatchewan
 - [Mesht Saskatchewan (Telegram)](https://t.me/MeshtSaska)
+
+### China
+**[`^        back to top        ^`](#awesome-meshtastic)**
+- [MeshCN](https://meshcn.net/)
 
 ### Finland
 **[`^        back to top        ^`](#awesome-meshtastic)**


### PR DESCRIPTION
[MeshCN](https://meshcn.net) currently is the only Meshtastic user group here in China. 

This PR adds it to the communities list.