### PR TITLE
Add PotatoMesh to Maps/Federated section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Tools for the every-user to see whats going on in general.
 - [Meshmap.net](https://meshmap.net/) - [Source code](https://github.com/brianshea2/meshmap.net)
 - [MeshSense Global Map](https://meshsense.affirmatech.com/) - [Source code](https://github.com/Affirmatech/MeshSense)
 
+### Federated
+
+- [PotatoMesh](https://potatomesh.net/) - [Source code](https://github.com/l5yth/potato-mesh)
+
 ### Regional
 
 - [Bay Area Meshview](https://meshview.bayme.sh/map)


### PR DESCRIPTION
PotatoMesh is a local-first, radio-only meshtastic dashboard that federates with other local communities around the globe.

https://github.com/l5yth/potato-mesh

Since it's neither Global nor Regional, I added a subheading for "Federated."