### PR TITLE
Add Disaster Comms with Meshtastic + MeshCore to Guides & Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A collection of useful guides and getting started information for the new Meshta
 - [Antenna Reports](https://github.com/meshtastic/antenna-reports) - Official Meshtastic community antenna reports
 - [Meshtastic RF Connector Types](https://pole1.co.uk/blog/5/) - Visual dictionary of RF connector types commonly found on Meshtastic radios and antennas. Many detailed macro photos.
 - [Meshtastic Quick-Start Video Guide (iOS)](https://www.youtube.com/watch?v=IoaoYbrdtlU) - Short video showing radio setup and basic functions on iOS App
+- [Disaster Comms with Meshtastic + MeshCore](https://pamfinds.com/guides/disaster-comms-meshtastic-meshcore/) - Guide to surviving infrastructure meltdown with a 3-node household kit (base station, go-bag node with GPS, solar relay). Covers hardware selection, pre-event configuration, range realities, power budgeting, and the Meshtastic vs MeshCore tradeoff.
 
 ## Maps and Diagnostics
 


### PR DESCRIPTION
Adds a guide that fits the Guides & Getting Started section: Disaster Comms with Meshtastic + MeshCore.

Link: https://pamfinds.com/guides/disaster-comms-meshtastic-meshcore/

The guide is original substantive content (not a thin affiliate page). Slots in alongside the existing AustinMesh and Comms Channel resources.