### PR TITLE
Add Red Grid MGRS to Local Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Is it software, but not for a server? For you, your phone or your computer? You 
 - [Meshtastic Visualizer](https://github.com/antlas0/meshtastic_visualizer) - Python PyQT desktop app to interface with local nodes, or subscribing to MQTT servers
 - [Meshtastic Plugin for Pidgin](https://github.com/dadecoza/pidgin-meshtastic) - A plugin to enable you to use Meshtastic with Pidgin (a multiplatform chat client)
 - [MeshStation](https://github.com/IronGiu/MeshStation) - Multi-platform SDR analyzer and desktop GUI for decoding and visualizing Meshtastic traffic using RTL-SDR or other SDR hardware
+- [Red Grid MGRS](https://redgridtactical.com/mgrs) - Offline MGRS/tactical-map navigator (iOS/Android) that shows Meshtastic node positions with grid, bearing, and distance over BLE. No accounts, no tracking.
 
 ## Hacks and Projects
 


### PR DESCRIPTION
Adds Red Grid MGRS to the Local Software section. It's an MGRS/land-nav app for iOS and Android that connects to Meshtastic radios over BLE and shows mesh node positions (MGRS grid, bearing, distance) on an offline tactical map. No accounts, no analytics, no tracking; position sharing is explicit and session-based. I'm the developer. Website: https://redgridtactical.com/mgrs - Source: https://github.com/RedGridTactical/RedGridMGRS - App Store: https://apps.apple.com/app/id6759629554 - Google Play: https://play.google.com/store/apps/details?id=com.redgrid.redgridtactical